### PR TITLE
CMake update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,22 @@
 # CMake script for Bio++ Remote Acnuc Access
-# Author: Sylvain Gaillard and Julien Dutheil
+# Authors:
+#   Sylvain Gaillard
+#   Julien Dutheil
+#   Francois Gindraud (2017)
 # Created: 11/09/2009
 
-# Global parameters
-cmake_minimum_required(VERSION 2.6)
-project(bpp-raa C CXX)
-if(NOT DEFINED CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE "Release")
-endif(NOT DEFINED CMAKE_BUILD_TYPE)
-set(CMAKE_CXX_FLAGS "-std=c++11 -Wall")
+cmake_minimum_required (VERSION 2.8.12)
+project (bpp-raa C CXX)
+
+# Compile options (see src/CMakeLists.txt for details about where to place options)
+set (private-cxx-compile-options -std=c++11)
+set (private-compile-options -Wall)
+
+IF(NOT CMAKE_BUILD_TYPE)
+  SET(CMAKE_BUILD_TYPE Release CACHE STRING
+      "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel."
+      FORCE)
+ENDIF(NOT CMAKE_BUILD_TYPE)
 
 IF(NOT NO_DEP_CHECK)
   SET(NO_DEP_CHECK FALSE CACHE BOOL
@@ -28,59 +36,57 @@ ELSE(NO_DEP_CHECK)
 #           library implements.
 # In other words, the library implements all the interface numbers in the
 # range from number current - age to current.
-set(BPPRAA_VERSION_CURRENT "2")
-set(BPPRAA_VERSION_REVISION "1")
-set(BPPRAA_VERSION_AGE "1")
+SET(${PROJECT_NAME}_VERSION_CURRENT "2")
+SET(${PROJECT_NAME}_VERSION_REVISION "1")
+SET(${PROJECT_NAME}_VERSION_AGE "1")
 
 # Effective version number computation
-math(EXPR BPPRAA_VERSION_MAJOR "${BPPRAA_VERSION_CURRENT} -
-${BPPRAA_VERSION_AGE}")
-set(BPPRAA_VERSION_MINOR ${BPPRAA_VERSION_AGE})
-set(BPPRAA_VERSION_PATCH ${BPPRAA_VERSION_REVISION})
-set(BPPRAA_VERSION "${BPPRAA_VERSION_MAJOR}.${BPPRAA_VERSION_MINOR}.${BPPRAA_VERSION_PATCH}")
+math(EXPR ${PROJECT_NAME}_VERSION_MAJOR "${${PROJECT_NAME}_VERSION_CURRENT} - ${${PROJECT_NAME}_VERSION_AGE}")
+SET(${PROJECT_NAME}_VERSION_MINOR ${${PROJECT_NAME}_VERSION_AGE})
+SET(${PROJECT_NAME}_VERSION_PATCH ${${PROJECT_NAME}_VERSION_REVISION})
+SET(${PROJECT_NAME}_VERSION "${${PROJECT_NAME}_VERSION_MAJOR}.${${PROJECT_NAME}_VERSION_MINOR}.${${PROJECT_NAME}_VERSION_PATCH}")
 
-# Set the CMAKE_PREFIX_PATH for the find_library fonction when using non
-# standard install location
-IF(CMAKE_INSTALL_PREFIX)
-  SET(CMAKE_PREFIX_PATH "${CMAKE_INSTALL_PREFIX}" ${CMAKE_PREFIX_PATH})
-ENDIF(CMAKE_INSTALL_PREFIX)
+set (PROJECT_VERSION ${${PROJECT_NAME}_VERSION})
 
-#here is a useful function:
-MACRO(IMPROVED_FIND_LIBRARY OUTPUT_LIBS lib_name include_to_find)
-  #start:
-  FIND_PATH(${lib_name}_INCLUDE_DIR ${include_to_find})
-  SET(${lib_name}_NAMES ${lib_name} ${lib_name}lib ${lib_name}dll)
-  FIND_LIBRARY(${lib_name}_LIBRARY NAMES ${${lib_name}_NAMES} PATH_SUFFIXES lib${LIB_SUFFIX})
+# Find dependencies (add install directory to search)
+if (CMAKE_INSTALL_PREFIX)
+  set (CMAKE_PREFIX_PATH "${CMAKE_INSTALL_PREFIX}" ${CMAKE_PREFIX_PATH})
+endif (CMAKE_INSTALL_PREFIX)
 
-  IF(${lib_name}_LIBRARY)
-    MESSAGE("-- Library ${lib_name} found here:")
-    MESSAGE("   includes : ${${lib_name}_INCLUDE_DIR}")
-    MESSAGE("   libraries: ${${lib_name}_LIBRARY}")
-  ELSE(${lib_name}_LIBRARY)
-    MESSAGE(FATAL_ERROR "${lib_name} required but not found.")
-  ENDIF(${lib_name}_LIBRARY)
-  
-  #add the dependency:
-  INCLUDE_DIRECTORIES(${${lib_name}_INCLUDE_DIR})
-  SET(${OUTPUT_LIBS} ${${OUTPUT_LIBS}} ${${lib_name}_LIBRARY})
-ENDMACRO(IMPROVED_FIND_LIBRARY)
+find_package (bpp-seq 9.1.3 REQUIRED)
 
-#Find the Bio++ libraries:
-IMPROVED_FIND_LIBRARY(LIBS bpp-seq Bpp/Seq/Alphabet/Alphabet.h)
-#Not explicitely needed:
-#IMPROVED_FIND_LIBRARY(LIBS bpp-core Bpp/Clonable.h)
-
-# Find the zlib installation
+# Find the zlib installation (define zlib imported target)
 find_package(ZLIB REQUIRED)
-include_directories(${ZLIB_INCLUDE_DIR})
-set(LIBS ${LIBS} ${ZLIB_LIBRARIES})
+add_library (zlib IMPORTED UNKNOWN)
+set_target_properties (zlib PROPERTIES
+  IMPORTED_LOCATION ${ZLIB_LIBRARIES}
+  INTERFACE_INCLUDE_DIRECTORIES ${ZLIB_INCLUDE_DIR}
+  )
 
-# Subdirectories
-add_subdirectory(src)
+# CMake package
+set (cmake-package-location lib/cmake/${PROJECT_NAME})
+include (CMakePackageConfigHelpers)
+configure_package_config_file (
+  package.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/package.cmake
+  INSTALL_DESTINATION ${cmake-package-location}
+  )
+write_basic_package_version_file (
+  ${CMAKE_CURRENT_BINARY_DIR}/package-version.cmake
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY SameMajorVersion
+  )
+install (FILES ${CMAKE_CURRENT_BINARY_DIR}/package.cmake DESTINATION ${cmake-package-location}
+  RENAME ${PROJECT_NAME}-config.cmake)
+install (FILES ${CMAKE_CURRENT_BINARY_DIR}/package-version.cmake DESTINATION ${cmake-package-location}
+  RENAME ${PROJECT_NAME}-config-version.cmake)
+
+# Define the libraries
+add_subdirectory (src)
 
 # Doxygen
-find_package(Doxygen)
-if (DOXYGEN_FOUND)
+FIND_PACKAGE(Doxygen)
+IF (DOXYGEN_FOUND)
   ADD_CUSTOM_TARGET (apidoc cp Doxyfile ${CMAKE_BINARY_DIR}/Doxyfile-build
     COMMAND echo "OUTPUT_DIRECTORY=${CMAKE_BINARY_DIR}" >> ${CMAKE_BINARY_DIR}/Doxyfile-build
     COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_BINARY_DIR}/Doxyfile-build
@@ -90,7 +96,7 @@ if (DOXYGEN_FOUND)
     COMMAND echo "HTML_HEADER=header.html" >> ${CMAKE_BINARY_DIR}/Doxyfile-stable
     COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_BINARY_DIR}/Doxyfile-stable
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-endif (DOXYGEN_FOUND)
+ENDIF (DOXYGEN_FOUND)
 
 ENDIF(NO_DEP_CHECK)
 

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -1,12 +1,23 @@
-This software needs cmake >= 2.6 to build.
+This software needs cmake >= 2.8.12 and a C++11 capable compiler to build
 
 After installing cmake, run it with the following command:
-cmake -DCMAKE_INSTALL_PREFIX=[where to install, for instance /usr/local or $HOME/.local] .
+$ cmake -DCMAKE_INSTALL_PREFIX=[where to install, for instance /usr/local or $HOME/.local] .
 
 If available, you can also use ccmake instead of cmake for a more user-friendly interface.
 
-Then compile and install the software with
-make install
+Then compile and install the software with:
+$ make install
 
 You may also consider installing and using the software checkinstall for easier system administration.
 
+If you install Bio++ in a non standard path (not /usr/), remember that:
+-> if you compile your project with CMake, give it the path with -DCMAKE_PREFIX_PATH=<path>
+-> if you compile with something else, give the path to the compiler (-I / -L options)
+-> if you use shared libraries, you must also tell programs where to find them at startup:
+  -> either by adding the path to LD_LIBRARY_PATH environment variable.
+  -> or by using RPATHs to hard code the path in the executable (generates NON PORTABLE executables !)
+    -> with CMake, see documentation in bpp-core/cmake/project-template
+    -> or see your compiler documentation ("-Wl,-rpath,<path>" for clang/gcc)
+    -> consider installing Bio++ with the "-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=TRUE" option
+
+Detailed documentation for using Bio++ with CMake are available in bpp-core/cmake/

--- a/package.cmake.in
+++ b/package.cmake.in
@@ -1,0 +1,26 @@
+# CMake package file for Bio++ Remote Acnuc Access
+# Authors:
+#   Francois Gindraud (2017)
+# Created: 16/03/2017
+@PACKAGE_INIT@
+
+if (NOT @PROJECT_NAME@_FOUND)
+  # Deps
+  find_package (bpp-seq @bpp-seq_VERSION@ REQUIRED)
+  # Add targets
+  include ("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
+  # Append targets to convenient lists
+  set (BPP_LIBS_STATIC "${BPP_LIBS_STATIC}" @PROJECT_NAME@-static)
+  set (BPP_LIBS_SHARED "${BPP_LIBS_SHARED}" @PROJECT_NAME@-shared)
+  # Print some path info for targets
+  get_property (static-location TARGET @PROJECT_NAME@-static PROPERTY LOCATION)
+  get_property (shared-location TARGET @PROJECT_NAME@-shared PROPERTY LOCATION)
+  get_property (header-location TARGET @PROJECT_NAME@-static PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
+  message (STATUS "@PROJECT_NAME@ @PROJECT_VERSION@ found:")
+  message (STATUS "  static lib: ${static-location}")
+  message (STATUS "  shared lib: ${shared-location}")
+  message (STATUS "  includes: ${header-location}")
+  unset (static-location)
+  unset (shared-location)
+  unset (header-location)
+endif (NOT @PROJECT_NAME@_FOUND)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,52 +1,68 @@
 # CMake script for Bio++ Remote Acnuc Access
-# Author: Sylvain Gaillard and Julien Dutheil
+# Authors:
+#   Sylvain Gaillard
+#   Julien Dutheil
+#   Francois Gindraud (2017)
 # Created: 11/09/2009
 
-# File list
-set(C_FILES
- Bpp/Raa/md5.c
- Bpp/Raa/parser.c
- Bpp/Raa/zsockr.c
- Bpp/Raa/misc_acnuc.c
- Bpp/Raa/RAA_acnuc.c
-)
+set (C_FILES
+  Bpp/Raa/RAA_acnuc.c
+  Bpp/Raa/md5.c
+  Bpp/Raa/misc_acnuc.c
+  Bpp/Raa/parser.c
+  Bpp/Raa/zsockr.c
+  )
 
-set(CPP_FILES
- Bpp/Raa/RAA.cpp
- Bpp/Raa/RaaList.cpp
- Bpp/Raa/RaaSpeciesTree.cpp
-)
+set (CPP_FILES
+  Bpp/Raa/RAA.cpp
+  Bpp/Raa/RaaList.cpp
+  Bpp/Raa/RaaSpeciesTree.cpp
+  )
 
-set(H_FILES
- Bpp/Raa/parser.h
- Bpp/Raa/RAA.h
- Bpp/Raa/RaaSeqAttributes.h
- Bpp/Raa/RAA_acnuc.h
- Bpp/Raa/RaaList.h
- Bpp/Raa/RaaSpeciesTree.h
-)
+# Here we have both C and CPP files, so -std=c++11 must not be applied to C_FILES.
+# Cpp specific options (-std=c++11) are placed in *-cxx-compile-options.
+# *-cxx-compile-options are applied to source files (and not whole target), and also to interface.
+# -Wall in private-compile-options is valid in C and CPP, so it is placed at target level.
+set_source_files_properties (${CPP_FILES} PROPERTIES
+  COMPILE_FLAGS ${private-cxx-compile-options}
+  )
 
 # Build the static lib
-add_library(bppraa-static STATIC ${CPP_FILES} ${C_FILES})
-set_target_properties(bppraa-static
-  PROPERTIES OUTPUT_NAME bpp-raa
-  CLEAN_DIRECT_OUTPUT 1
+add_library (${PROJECT_NAME}-static STATIC ${CPP_FILES} ${C_FILES})
+target_include_directories (${PROJECT_NAME}-static PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include>
   )
-target_link_libraries(bppraa-static ${LIBS})
+set_target_properties (${PROJECT_NAME}-static PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
+target_link_libraries (${PROJECT_NAME}-static ${BPP_LIBS_STATIC} zlib)
+target_compile_options (${PROJECT_NAME}-static PRIVATE ${private-compile-options})
 
 # Build the shared lib
-add_library(bppraa-shared SHARED ${CPP_FILES} ${C_FILES})
-set_target_properties(bppraa-shared
-  PROPERTIES OUTPUT_NAME bpp-raa
-  CLEAN_DIRECT_OUTPUT 1
-  VERSION ${BPPRAA_VERSION}
-  SOVERSION ${BPPRAA_VERSION_MAJOR}
+add_library (${PROJECT_NAME}-shared SHARED ${CPP_FILES} ${C_FILES})
+target_include_directories (${PROJECT_NAME}-shared PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include>
   )
-target_link_libraries(bppraa-shared ${LIBS})
+set_target_properties (${PROJECT_NAME}-shared
+  PROPERTIES OUTPUT_NAME ${PROJECT_NAME}
+  MACOSX_RPATH 1
+  VERSION ${${PROJECT_NAME}_VERSION}
+  SOVERSION ${${PROJECT_NAME}_VERSION_MAJOR}
+  )
+target_link_libraries (${PROJECT_NAME}-shared ${BPP_LIBS_SHARED} zlib)
+target_compile_options (${PROJECT_NAME}-shared PRIVATE ${private-compile-options})
 
-# Install libs
-install(TARGETS bppraa-static bppraa-shared DESTINATION lib${LIB_SUFFIX})
-
-# Install headers
-install(DIRECTORY Bpp/ DESTINATION include/Bpp FILES_MATCHING PATTERN "*.h")
-
+# Install libs and headers
+install (
+  TARGETS ${PROJECT_NAME}-static ${PROJECT_NAME}-shared
+  EXPORT ${PROJECT_NAME}-targets
+  LIBRARY DESTINATION lib${LIB_SUFFIX}
+  ARCHIVE DESTINATION lib${LIB_SUFFIX}
+  )
+install (
+  DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Bpp
+  DESTINATION include
+  FILES_MATCHING PATTERN "*.h"
+  )
+# Install cmake file representing targets
+install (EXPORT ${PROJECT_NAME}-targets DESTINATION ${cmake-package-location})


### PR DESCRIPTION
Added delayed stuff from pthe global bpp cmake update, plus:

Remove propagation of "-std=c++11" flag, might pose problem for users.
Fix install of CMake internal dirs along with headers
Fix corner case encountered by Laurent (find_package finding a build
tree package file if src gits are placed in <prefix>/ with in place
builds).
Added CMake doc for users (INSTALL.txt).
Added notice for C++11 requirement.